### PR TITLE
Fully automate dev setup with Gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:20.04
+LABEL maintainer="Niklas Hauser <niklas.hauser@rwth-aachen.de>"
+LABEL Description="Image for building and debugging arm-embedded projects from git"
+WORKDIR /work
+
+ADD . /work
+
+# Install any needed packages specified in requirements.txt
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+# Development files
+      build-essential \
+      git \
+      bzip2 \
+      wget && \
+    apt-get clean
+RUN wget -qO- https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 | tar -xj
+
+ENV PATH "/work/gcc-arm-none-eabi-9-2019-q4-major/bin:$PATH"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: make

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/martinribelotta/cmx-debug)
+
 # Thumb/Thumb2 monitor-debug utility
 
 This program intent to provide similar function as MSDOS command


### PR DESCRIPTION
This commit implements a fully-automated development setup using Gitpod.io, an
online IDE for GitHub and GitLab that enables Dev-Environments-As-Code.
This makes it easy for anyone to get a ready-to-code workspace for any branch,
issue or pull request almost instantly with a single click.